### PR TITLE
Separate problem id and name with a dash instead of a dot

### DIFF
--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -436,18 +436,20 @@ function! s:SlugToFileName(slug) abort
 endfunction
 
 function! s:ProblemSlugFromFileName() abort
-    let parts = split(expand('%:t:r'), '\.')  " Filename without the extension
+    " 1-two_sum -> 1.two-sum
+    let file_name = substitute(expand('%:t:r'), '-', '\.', 'g')
+    let parts = split(file_name, '\.')  " Filename without the extension
     if len(parts) == 1
-        " Old style, e.g. two-sum
+        " Old style, e.g. two_sum
         return s:FileNameToSlug(parts[0])
     elseif len(parts) == 2 && parts[0] =~ '\v^[0-9]+$'
-        " New style, e.g. 1.two-sum
+        " New style, e.g. 1.two_sum
         return s:FileNameToSlug(parts[1])
     elseif len(parts) == 2
-        " Old style with submission id, e.g. two-sum.1234 
+        " Old style with submission id, e.g. two_sum.1234
         return s:FileNameToSlug(parts[0])
     elseif len(parts) == 3
-        " New style with submission id, e.g. 1.two-sum.1234
+        " New style with submission id, e.g. 1.two_sum.1234
         return s:FileNameToSlug(parts[1])
     else
         throw 'leetcode: invalid file name: ' . expand('%:t:r')
@@ -509,7 +511,7 @@ function! s:HandleProblemListCR() abort
         let problem = s:GetProblem(problem_id)
         let problem_slug = problem['slug']
         let problem_ext = s:SolutionFileExt(g:leetcode_solution_filetype)
-        let problem_file_name = printf('%s.%s.%s', problem_id,
+        let problem_file_name = printf('%s-%s.%s', problem_id,
                     \  s:SlugToFileName(problem_slug),
                     \ problem_ext)
 
@@ -1175,7 +1177,7 @@ function! s:HandleSubmissionsCR() abort
         return
     endif
 
-    let file_name = printf('%s.%s.%s.%s', 
+    let file_name = printf('%s-%s.%s.%s',
                 \ submission['problem_id'],
                 \ s:SlugToFileName(submission['slug']),
                 \ submission_id, s:SolutionFileExt(submission['filetype']))


### PR DESCRIPTION
In case we wanna compile locally, the following error occors with rustc:

```
❯ rustc 1.two_sum.rs
error: invalid character `.` in crate name: `1.two_sum`

error: aborting due to previous error
```

Fix misleading comments and trailing spaces while at it.