### PR TITLE
fix div-zero err in new problem's ac_rate

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -217,7 +217,8 @@ def _get_category_problems(category):
                    'title': p['stat']['question__title'],
                    'slug': p['stat']['question__title_slug'],
                    'paid_only': p['paid_only'],
-                   'ac_rate': p['stat']['total_acs'] / p['stat']['total_submitted'],
+                   'ac_rate': p['stat']['total_acs'] / p['stat']['total_submitted'] if \
+                                p['stat']['total_submitted'] > 0 else 0,
                    'level': _level_to_name(p['difficulty']['level']),
                    'favor': p['is_favor'],
                    'category': content['category_slug'],


### PR DESCRIPTION
I encounter a `div-zero` error like this:

![image](https://user-images.githubusercontent.com/53598282/231355287-3d302db2-511b-4c37-8c09-3baaa61c8425.png)

For new problems, there might be no submissions so `p['stat']['total_submitted']` can be zero.

Better add additional check before calculating.