### PR TITLE
Fix ValueError in  get_submission() when doing int()

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -541,7 +541,7 @@ def get_submission(sid):
     # the second key "runtime" is the runtime in milliseconds
     # we need to search from the position after the first "runtime" key
     prev_runtime = re.search("runtime: '([^']*)'", s)
-    if not prev_runtime:
+    if not prev_runtime or not _group1(prev_runtime, 'N/A').split()[0].isdigit():
         my_runtime = 0
     else:
         my_runtime = int(_group1(re.search("runtime: '([^']*)'", s[prev_runtime.end():]), 0))


### PR DESCRIPTION
If the result of get_submissions() contains some invalid submissions, such as compile error,
it will cause get_submission() to get a non-integer value when fetching the runtime, which will cause a ValueError.

<img width="1727" alt="ValueError in get_submission" src="https://github.com/briemens/leetcode.vim/assets/20947944/3ba53e46-9f30-48a9-9796-6cea5dcc9a34">
